### PR TITLE
Increase memory on git pull job

### DIFF
--- a/model/slurm_scripts/git_pull_JHU.slurm
+++ b/model/slurm_scripts/git_pull_JHU.slurm
@@ -3,7 +3,7 @@
 #SBATCH --mail-type=FAIL
 #SBATCH --time=10:00
 #SBATCH --job-name=git_pull_JHU
-#SBATCH --mem-per-cpu=1G
+#SBATCH --mem-per-cpu=2G
 #SBATCH --output=/home/%u/slurm_output/slurm-%A_%a.out
 #SBATCH --account=covid19_project1
 #SBATCH --partition=standard


### PR DESCRIPTION
This resolves an issue with the git pull job being killed for using
too much memory