### PR TITLE
future-proof data stacking

### DIFF
--- a/model/r_scripts/pull_cowin_data.R
+++ b/model/r_scripts/pull_cowin_data.R
@@ -38,10 +38,10 @@ dd <- latest_vax_data[place %in% c("Dadra and Nagar Haveli", "Daman and Diu")][,
 india <- latest_vax_data[, lapply(.SD, sum, na.rm = TRUE), .SDcols = c("total_doses", "first_dose", "second_dose")][, place := "India"][]
 
 vax <- rbindlist(list(
-  latest_vax_data[!(place %in% c("Dadra and Nagar Haveli", "Daman and Diu"))][, precaution_dose := NULL],
+  latest_vax_data[!(place %in% c("Dadra and Nagar Haveli", "Daman and Diu"))],
   dd,
   india
-), use.names = TRUE)[, `:=` (
+), fill = TRUE, use.names = TRUE)[, `:=` (
   date          = as.Date(content$timestamp),
   raw_timestamp = content$timestamp,
   pull_time     = Sys.time()


### PR DESCRIPTION
Hard-coding the removal of `precaution_dose` could fix this issue. however, if additional columns were added in the future, or if `precaution_dose` were removed from the data source, then we would run into this error again. I propose `fill = TRUE`, which will adaptively capture changes to columns/names in the underlying data source moving forward. If the data frame accumulates too many columns, we can start pruning at that point.